### PR TITLE
Set `tutorial: true` for tutorial cutout of KZ

### DIFF
--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -144,6 +144,7 @@ databundles:
   # Cutout of Kazakhstan for CI test of pypsa-kz-data repo, only 5 MB
   bundle_cutouts_test_KZ:
     countries: [KZ]
+    tutorial: true
     category: cutouts
     destination: "cutouts"
     urls:


### PR DESCRIPTION
## Changes proposed in this Pull Request

Good day. This PR aims to fix the issue of downloading of tutorial cutouts for KZ by default, when simulating KZ. We have tutorial cutouts; however, they are not marked as tutorial. As a result, when you simulate the KZ using default config, smaller cutout is downloaded.


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
