### PR TITLE
Fix prepare_ports and prepare_airports aggregations with recent pandas

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -44,6 +44,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Fix pandas compatibility in `prepare_ports.py` and `prepare_airports.py` [PR #1917](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1917)
+
 * Replace deprecated UNCTAD urban population download endpoint in `prepare_urban_percent.py` [PR #1881](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1881)
 
 * Remove unused `add_extendable_generators` function in `add_electricity.py` script [PR #1854](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1854)

--- a/scripts/prepare_airports.py
+++ b/scripts/prepare_airports.py
@@ -62,8 +62,7 @@ def preprocess_airports(df):
 
     # Calculate the number of total airports size
     df1 = df.copy()
-    df1 = df1.groupby(["iso_country"]).sum("airport_size_nr")
-    df1 = df1[["airport_size_nr"]]
+    df1 = df1.groupby("iso_country")[["airport_size_nr"]].sum()
     df1 = df1.rename(columns={"airport_size_nr": "Total_airport_size_nr"}).reset_index()
 
     # Merge dataframes to get additional info on runnway for most ports

--- a/scripts/prepare_ports.py
+++ b/scripts/prepare_ports.py
@@ -126,8 +126,7 @@ if __name__ == "__main__":
     ports.loc[ports["Harbor Size"].isin(["Large"]), "Harbor_size_nr"] = 3
 
     df1 = ports.copy()
-    df1 = df1.groupby(["country_full_name"]).sum("Harbor_size_nr")
-    df1 = df1[["Harbor_size_nr"]]
+    df1 = df1.groupby("country_full_name")[["Harbor_size_nr"]].sum()
     df1 = df1.rename(columns={"Harbor_size_nr": "Total_Harbor_size_nr"})
 
     ports = ports.set_index("country_full_name").join(df1, how="left")


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes pandas compatibility issues in both `scripts/prepare_ports.py` and `scripts/prepare_airports.py`.

The previous implementation used:

```python
df.groupby(...).sum("column")
```

With recent pandas versions, the positional argument to `sum()` is interpreted as the `numeric_only` parameter, resulting in:

```text
ValueError: numeric_only accepts only Boolean values
```

This PR replaces those calls with explicit column selection before aggregation:

```python
df.groupby(...)[["column"]].sum()
```

which preserves the original behavior while remaining compatible with both older and newer pandas releases.


## Checklist

- [ ] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
