### PR TITLE
Fix geometry indexing in build_population_layouts

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -44,6 +44,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Fix geometry indexing in `build_population_layouts` [PR #1919](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1919)
+
 * Replace deprecated UNCTAD urban population download endpoint in `prepare_urban_percent.py` [PR #1881](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1881)
 
 * Remove unused `add_extendable_generators` function in `add_electricity.py` script [PR #1854](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1854)

--- a/scripts/build_population_layouts.py
+++ b/scripts/build_population_layouts.py
@@ -38,12 +38,15 @@ if __name__ == "__main__":
     # Set value of population to same dimension as in PyPSA-Eur-Sec, where the value is given in 1e3
     nuts3["pop"] = nuts3["pop"] / 1000
 
-    # Indicator matrix NUTS3 -> grid cells
-    I = atlite.cutout.compute_indicatormatrix(nuts3.geometry, grid_cells)
+    # atlite expects geometries to be accessible by integer labels starting at 0.
+    nuts3_geometry = nuts3.geometry.reset_index(drop=True)
 
-    # Indicator matrix grid_cells -> NUTS3; inprinciple Iinv*I is identity
-    # but imprecisions mean not perfect
-    Iinv = cutout.indicatormatrix(nuts3.geometry)
+    # Indicator matrix NUTS3 -> grid cells
+    I = atlite.cutout.compute_indicatormatrix(nuts3_geometry, grid_cells)
+
+    # Indicator matrix grid_cells -> NUTS3; in principle Iinv * I is identity,
+    # but imprecisions mean not perfect.
+    Iinv = cutout.indicatormatrix(nuts3_geometry)
 
     countries = np.sort(nuts3.country.unique())
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR fixes a compatibility issue in `scripts/build_population_layouts.py`.

The script stores the administrative regions using `GADM_ID` as the index, but `atlite.compute_indicatormatrix()` expects the input geometries to be indexed by consecutive integer labels. With a non-default index, recent versions raise a KeyEroor.

This PR resets only the index of the geometry passed to atlite:

```python
nuts3_geometry = nuts3.geometry.reset_index(drop=True)
```

while preserving the original `GeoDataFrame` index (`GADM_ID`) for all subsequent lookups and aggregations.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
