### PR TITLE
Filter lines that have no geometry

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -12,6 +12,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **New Features and Major Changes**
 
+* Add a fix to remove empty geometries in `build_osm_network` script [PR #1929](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1929)
+
 * Add gis based underground hydrogen storage (salt carverns) and h2 turbine [PR #1474](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1474)
 
 * Add docstrings and type hints for core sector model scripts [PR #1880](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1880)

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -127,6 +127,9 @@ def set_lines_ids(lines, buses, distance_crs):
     lines["bus0"] = -1
     lines["bus1"] = -1
 
+    # Filter lines that are empty
+    lines_d = lines_d[~lines_d.geometry.boundary.is_empty]
+    
     for key, lines_sel in lines_d.groupby(["voltage", "dc"]):
         buses_sel = buses_d.query(f"voltage == {key[0]} and dc == {key[1]}")
 

--- a/scripts/build_osm_network.py
+++ b/scripts/build_osm_network.py
@@ -129,7 +129,7 @@ def set_lines_ids(lines, buses, distance_crs):
 
     # Filter lines that are empty
     lines_d = lines_d[~lines_d.geometry.boundary.is_empty]
-    
+
     for key, lines_sel in lines_d.groupby(["voltage", "dc"]):
         buses_sel = buses_d.query(f"voltage == {key[0]} and dc == {key[1]}")
 


### PR DESCRIPTION
# Closes # (if applicable)

## Changes proposed in this Pull Request
In this PR, I have added a modification to `build_osm_network` script. When building the model for US, came across the issue where finding the closest nodes for a line fails with `Index Out of range` error as following

<img width="1296" height="917" alt="Screenshot 2026-07-08 005848" src="https://github.com/user-attachments/assets/99f75818-7c5b-46b3-bb5e-4fda48a95531" />

This is due to an empty geometry row as shown in the following screenshot

<img width="675" height="111" alt="Screenshot 2026-07-08 005809" src="https://github.com/user-attachments/assets/2e968bd3-725d-432e-9a6d-4097fd6825a0" />

To remove, empty geometries, a filtering has been added to the code

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
