### PR TITLE
Fix encoding errors in win32 machines for running CLI

### DIFF
--- a/scripts/non_workflow/pypsa_earth_cli.py
+++ b/scripts/non_workflow/pypsa_earth_cli.py
@@ -18,6 +18,14 @@ import subprocess
 import sys
 from enum import Enum
 
+# On Windows, the legacy console codepage (e.g. cp1252) cannot encode some of the
+# emojis used in the CLI output, which raises a UnicodeEncodeError as soon as
+# `rich` tries to print them. Force stdout/stderr to UTF-8 so the CLI runs
+# regardless of the active console codepage.
+if sys.platform == "win32":
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    sys.stderr.reconfigure(encoding="utf-8", errors="replace")
+
 import typer
 import yaml
 from InquirerPy import get_style, inquirer


### PR DESCRIPTION
# Closes # (if applicable)

## Changes proposed in this Pull Request
In this PR, a fix for the encoding issue as raised in #1947 is applied.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [ ] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
