### PR TITLE
Avoid excessive warnings when normalising tutorial hydrobasins

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -180,6 +180,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Avoid excessive warnings when normalising hydrobasins [PR #1951](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1951)
+
 * Add heuristics to infer missing hydropower technologies: if the energy-to-capacity ratio exceeds the threshold defined in `hydro_min_inflow_pu`, the plant is classified as a reservoir. Otherwise, it is treated as run-of-river [PR #1684](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1684)
 
 * Fix issues where gas and biomass powerplant capacity were not added in `add_existing_baseyear.py`. Differentiate `urban central solid biomass CHP` with non-CHP `biomass` for historical capacity [PR #1678](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1678)

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -936,6 +936,10 @@ def normalise_hydrobasins(config_hydrobasin: dict) -> None:
         for column, default in defaults.items():
             if column not in hydrobasins.columns:
                 hydrobasins[column] = default
+
+        required_columns = ["HYBAS_ID", "DIST_MAIN", "NEXT_DOWN", "geometry"]
+        hydrobasins = hydrobasins[required_columns]
+
     hydrobasins.to_file(output_fl, driver="ESRI Shapefile")
 
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Keep only the HydroBASINS attributes required by `atlite` when normalising the tutorial GEOGloWS dataset to avoid  unused fields causing `pyogrio` to emit a large number of repeated runtime warnings, flooding and eventually truncating the CI logs:

  - `HYBAS_ID`
  - `DIST_MAIN`
  - `NEXT_DOWN`
  - `geometry`

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
