### PR TITLE
Update databundle links to point to the new zenodo release

### DIFF
--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -98,10 +98,9 @@ databundles:
     category: hydrobasins
     destination: "data/hydrobasins_hydroshare"
     urls:
-      # TODO Double-check if rehosting is needed
+      zenodo: https://zenodo.org/records/18032587/files/africa-geoglows-catchment.zip?download=1
+      gdrive: https://drive.google.com/file/d/19IpXSlChTnrqGm57GLT3rjQiAnDcvGR0/view?usp=drive_link
       #direct: https://www.hydroshare.org/resource/121bbce392a841178476001843e7510b/data/contents/africa-geoglows-catchment.zip
-      zenodo: https://sandbox.zenodo.org/records/565987/files/africa-geoglows-catchment.zip?download=1
-    #output: [data/hydrobasins_hydroshare/africa-geoglows-catchment.shp]
     output: [data/hydrobasins_hydroshare/africa-geoglows-atlite.shp]
 
   # tutorial bundle specific for Nigeria and Benin only

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -36,8 +36,8 @@ databundles:
     category: data
     destination: "data"
     urls:
-      zenodo: https://zenodo.org/records/18851102/files/bundle_tutorial_NGBJ_with_gadmlike.zip?download=1
-      gdrive: https://drive.google.com/file/d/1XnTP6bZoVl5kFjZQlAcmjNXgazOHtFqX/view?usp=drive_link
+      zenodo: https://zenodo.org/records/18032587/files/bundle_tutorial_data_NGBJ.zip?download=1
+      gdrive: https://drive.google.com/file/d/1YOE1bh76CKV-0yfsdiBFm-lDNPK8Bk4k/view?usp=drive_link
     output:
     - data/gebco/GEBCO_2025_sub_ice.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
@@ -53,7 +53,8 @@ databundles:
     category: global_buildings
     destination: "data"
     urls:
-      gdrive: https://drive.google.com/file/d/1nnseF1A740Gp0IaryeCQ8IRcEF91-aUe/view?usp=drive_link
+      zenodo: https://zenodo.org/records/18032587/files/global_buildings.zip?download=1
+      gdrive: https://drive.google.com/file/d/1byLXjaL4Vp_-xW9sbx70PnXz1jNCijlj/view?usp=drive_link
     output:
     - data/global_buildings/NG_global_buildings_raw.parquet  # needed in cluster_global_buildings
     - data/global_buildings/BJ_global_buildings_raw.parquet  # needed in cluster_global_buildings
@@ -65,8 +66,8 @@ databundles:
     category: data
     destination: "data"
     urls:
-      zenodo: https://zenodo.org/records/18851102/files/bundle_tutorial_BW_with_gadmlike.zip?download=1
-      gdrive: https://drive.google.com/file/d/1AEmlgBO-6uY_MA4rzmaRJcQ-xE1Z4uHx/view?usp=drive_link
+      zenodo: https://zenodo.org/records/18032587/files/bundle_tutorial_data_BW.zip?download=1
+      gdrive: https://drive.google.com/file/d/1yHscE_U-56VGkH4TQHplvdgoQaWPj7wZ/view?usp=drive_link
     output:
     - data/gebco/GEBCO_2025_sub_ice.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
@@ -80,8 +81,8 @@ databundles:
     category: data
     destination: "data"
     urls:
-      zenodo: https://zenodo.org/records/18851102/files/bundle_tutorial_data_MA.zip?download=1
-      gdrive: https://drive.google.com/file/d/1cUei9vH3LzIYfqltaGTaRWCX6J24f1c0/view?usp=drive_link
+      zenodo: https://zenodo.org/records/18032587/files/bundle_tutorial_data_MA.zip?download=1
+      gdrive: https://drive.google.com/file/d/1QvEekIVMQkm4wjFBHSGKFkqehCcXyuaU/view?usp=drive_link
     output:
     - data/gebco/GEBCO_2025_sub_ice.nc
     - data/copernicus/PROBAV_LC100_global_v3.0.1_2019-nrt_Discrete-Classification-map_EPSG-4326.tif
@@ -110,8 +111,8 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://zenodo.org/records/18851102/files/bundle_cutouts_tutorial_NGBJ.zip?download=1
-      gdrive: https://drive.google.com/file/d/1xnomHdXf_c5STrf7jtDiuRlN2zW0FSVC/view?usp=drive_link
+      zenodo: https://zenodo.org/records/18032587/files/bundle_tutorial_cutouts_NGBJ.zip?download=1
+      gdrive: https://drive.google.com/file/d/1EH6m0VccTZMh0a7z_7XVr2mbLK0Z4jXq/view?usp=drive_link
     output: [cutouts/cutout-2013-era5-tutorial.nc]
     disable_by_opt:
       build_cutout: [all]
@@ -123,8 +124,8 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://zenodo.org/records/18851102/files/bundle_cutouts_tutorial_BW.zip?download=1
-      gdrive: https://drive.google.com/file/d/1DDQAtnIDM0FNC3vCldfHeH__IpTbyIJt/view?usp=drive_link
+      zenodo: https://zenodo.org/records/18032587/files/bundle_tutorial_cutouts_BW.zip?download=1
+      gdrive: https://drive.google.com/file/d/1LiugHfM92MmhZqcDQybaw2oblfOIwhcg/view?usp=drive_link
     output: [cutouts/cutout-2013-era5-tutorial.nc]
     disable_by_opt:
       build_cutout: [all]
@@ -136,8 +137,8 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://zenodo.org/records/18851102/files/bundle_cutouts_tutorial_MA.zip?download=1
-      gdrive: https://drive.google.com/file/d/1j5v2f4E756jmDMa707QvdNJq3xM4bYUk/view?usp=drive_link
+      zenodo: https://zenodo.org/records/18032587/files/bundle_tutorial_cutouts_MA.zip?download=1
+      gdrive: https://drive.google.com/file/d/1Q-wSxtbr58Lc8ZwHXR_kQQ876_U8MWpB/view?usp=drive_link
     output: [cutouts/cutout-2013-era5-tutorial.nc]
     disable_by_opt:
       build_cutout: [all]
@@ -149,7 +150,8 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://zenodo.org/records/18851102/files/bundle_tutorial_cutouts_KZ.zip?download=1
+      zenodo: https://zenodo.org/records/18032587/files/bundle_tutorial_cutouts_KZ.zip?download=1
+      gdrive: https://drive.google.com/file/d/1J9nsXrY__IF_1RJ1Ct4Ea-tFtWF0o6yh/view?usp=drive_link
     output: [cutouts/cutout-2013-era5-tutorial.nc]
     disable_by_opt:
       build_cutout: [all]
@@ -161,8 +163,8 @@ databundles:
     category: common
     destination: "data"
     urls:
-      zenodo: https://zenodo.org/records/18851102/files/tutorial_data_general.zip?download=1
-      gdrive: https://drive.google.com/file/d/1nRLrs_kP0qVl-IHC4BFLjpoKa3HLk2Py/view
+      zenodo: https://zenodo.org/records/18032587/files/bundle_tutorial_data_general.zip?download=1
+      gdrive: https://drive.google.com/file/d/1wq96sIJhvnPk0gUy4TwwBZ7_9AEags6Q/view?usp=drive_link
     output:
     - data/eez/eez_v11.gpkg
     - data/ssp2-2.6/2030/era5_2013/Africa.nc

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -51,7 +51,7 @@ databundles:
     countries: [NG, BJ]
     tutorial: true
     category: global_buildings
-    destination: "data"
+    destination: "data/global_buildings"
     urls:
       zenodo: https://zenodo.org/records/18032587/files/global_buildings.zip?download=1
       gdrive: https://drive.google.com/file/d/1byLXjaL4Vp_-xW9sbx70PnXz1jNCijlj/view?usp=drive_link

--- a/configs/bundle_config.yaml
+++ b/configs/bundle_config.yaml
@@ -241,8 +241,8 @@ databundles:
     category: common
     destination: "data"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/323567/files/bundle_data_earth.zip?download=1
-      gdrive: https://drive.google.com/file/d/1P4uMY464lgcp--8fAEYIJbKeNmHdg1Re/view?usp=drive_link
+      zenodo: https://zenodo.org/records/18033571/files/bundle_data_earth.zip?download=1
+      gdrive: https://drive.google.com/file/d/1lzIN7uNNaVjdRbKriQJBOZc8bS4Nur0u/view?usp=drive_link
     output:
     - data/eez/eez_v11.gpkg
     - data/gebco/GEBCO_2025_sub_ice.nc
@@ -260,7 +260,7 @@ databundles:
     category: natura
     destination: "data/natura/"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/323567/files/natura_wpda_CC0.zip?download=1
+      zenodo: https://zenodo.org/records/18033571/files/bundle_natura.zip?download=1
       gdrive: https://drive.google.com/file/d/1H-Y7p8UgnbEzJgo9qPc54BpDXS8loX7Y/view?usp=drive_link
     output:
     - data/natura/natura.tiff
@@ -306,63 +306,60 @@ databundles:
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/323567/files/bundle_cutouts_africa.zip?download=1
-      gdrive: https://drive.google.com/file/d/1WHv5Dm1GtrDZj-AxJZd3T-NMIBXty3eV/view?usp=drive_link
+      zenodo: https://zenodo.org/records/18032151/files/bundle_cutouts_africa.zip?download=1
+      gdrive: https://drive.google.com/file/d/1ACZ6Nx_homed3fiPMMHUGjDRM0GaaI6D/view?usp=drive_link
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]
 
   # # cutouts bundle of the cutouts folder for the whole African continent,
-  # # including UN countries offshore mainland Africa. Size about 20GB (zipped)
+  # # including UN countries offshore mainland Africa. Size about 21GB (zipped)
   # bundle_cutouts_whole_africa:
   #   countries: [Africa]
   #   category: cutouts
   #   destination: "cutouts"
   #   urls:
-  #     # zenodo:
-  #     gdrive: https://drive.google.com/file/d/1O_9vQ2SDluJ_LtFdRBeoo1Pz213n5HAN/view?usp=sharing
+  #     zenodo: https://zenodo.org/records/18032151/files/bundle_cutouts_africa_full.zip?download=1
+  #     gdrive: https://drive.google.com/file/d/1_j2zRbZCgBd6sRypJD5MgApalEGgc3V7/view?usp=drive_link
   #   output: [cutouts/cutout-2013-era5.nc]
   #   disable_by_opt:
   #     build_cutout: [all]
 
   # cutouts bundle of the cutouts folder for the North American continent
-  # Coordinate bounds: [long -172 to -47, lat 1.5-74]
-  # Size about 27 GB (zipped)
+  # Size about 30 GB (zipped)
   bundle_cutouts_northamerica:
     countries: [NorthAmerica]
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/418859/files/bundle_cutouts_northamerica.zip?download=1
-      gdrive: https://drive.google.com/file/d/1Ao_kuHssRaP1qLV-IEG91Hu7E04-nBZg/view?usp=drive_link
+      zenodo: https://zenodo.org/records/18186603/files/bundle_cutouts_northamerica.zip?download=1
+      gdrive: https://drive.google.com/file/d/1-R-SbtDfKWh71P3sFt6oZpWWa9g0P6K7/view?usp=drive_link
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]
 
   # cutouts bundle of the cutouts folder for the European continent
-  # Coordinate bounds: [long -32 to 60, lat 1.5-74]
-  # Size about 17 GB (zipped)
+  # Size about 18 GB (zipped)
   bundle_cutouts_europe:
     countries: [Europe]
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/418694/files/bundle_cutouts_europe.zip?download=1
-      gdrive: https://drive.google.com/file/d/1c2-8pChoxv4CDJW01vkPpggBSWHs9Mqi/view?usp=drive_link
+      zenodo: https://zenodo.org/records/18034282/files/bundle_cutouts_europe.zip?download=1
+      gdrive: https://drive.google.com/file/d/18dJJY6jLHsFzMaHm1lNUCKnUpsFLfb_e/view?usp=drive_link
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]
 
   # cutouts bundle of the cutouts folder for Oceania continent
-  # Coordinate bounds: [min_x = 80, max_x = 180.0, min_y = -50, max_y = 20.]
-  # Size about 19 GB (zipped)
+  # Size about 23 GB (zipped)
   bundle_cutouts_oceania:
     countries: [Oceania]
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/418864/files/bundle_cutouts_oceania.zip?download=1
-      gdrive: https://drive.google.com/file/d/1R8ELkXmW8jBBUFWRY0sbf-T14SJl4EUY/view?usp=sharing
+      zenodo: https://zenodo.org/records/18038936/files/bundle_cutouts_oceania.zip?download=1
+      gdrive: https://drive.google.com/file/d/1Xf7CWT8FZXL0rZnn8GzMCSZ-psjk-gzq/view?usp=drive_link
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]
@@ -380,14 +377,14 @@ databundles:
   #    build_cutout: [all]
 
   # cutouts bundle of the cutouts folder for the Asian continent, except Russia
-  # Size about 30GB (zipped)
+  # Size about 31GB (zipped)
   bundle_cutouts_asia:
     countries: ["KVR", "WAS", "FEAR", "SEAR", "CASR", "SASR", "ASEAN", "MEAR"]
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/418866/files/bundle_cutouts_asia.zip?download=1
-      gdrive: https://drive.google.com/file/d/11-Ax9tVks7oPjrZwG5v3C0x4OmMT_Pv8/view?usp=sharing
+      zenodo: https://zenodo.org/records/18039581/files/bundle_cutouts_asia.zip?download=1
+      gdrive: https://drive.google.com/file/d/1sTpcrnmDngvMFC6hw_ormowsbgqfqlsH/view?usp=drive_link
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]
@@ -405,39 +402,54 @@ databundles:
   #   disable_by_opt:
   #     build_cutout: [all]
 
-  # Cutout for South America, approx 18 GB
+  # Cutout for South America
+  # Size about 18 GB (zipped)
   bundle_cutouts_southamerica:
     countries: [SouthAmerica]
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/418859/files/bundle_cutouts_southamerica.zip?download=1
-      gdrive: https://drive.google.com/file/d/1Jeu2Vzoq4mNDUKSvIviN8HqSFx5gl61b/view?usp=sharing
+      zenodo: https://zenodo.org/records/19661490/files/bundle_cutouts_southamerica.zip?download=1
+      gdrive: https://drive.google.com/file/d/1y0EWRl6XKC0IrPhO8EMZvZ0zdK1Y8vQT/view?usp=drive_link
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]
 
   # cutouts bundle of the cutouts folder for Western Asia
-  # Size about 3.8 GB (zipped)
+  # Size about 4 GB (zipped)
   bundle_cutouts_westernasia:
     countries: [WAS]
     category: cutouts
     destination: "cutouts"
     urls:
-      zenodo: https://sandbox.zenodo.org/records/418694/files/bundle_cutouts_westasia.zip?download=1
-      gdrive: https://drive.google.com/file/d/1as-fZS4Z70CfDf3bR4i9t9S5-5pBqURP/view?usp=sharing
+      zenodo: https://zenodo.org/records/18033563/files/bundle_cutouts_westasia.zip?download=1
+      gdrive: https://drive.google.com/file/d/1ytSEcPdB9kxXUiNYoFDEQ16UPaIdqp5o/view?usp=drive_link
+    output: [cutouts/cutout-2013-era5.nc]
+    disable_by_opt:
+      build_cutout: [all]
+
+  # cutouts bundle of the cutouts folder for ASEAN region
+  # Size about 7 GB (zipped)
+  bundle_cutouts_asean:
+    countries: [ASEAN]
+    category: cutouts
+    destination: "cutouts"
+    urls:
+      zenodo: https://zenodo.org/records/20325289/files/bundle_cutouts_asean.zip?download=1
+      gdrive: https://drive.google.com/file/d/1-5bHy7V9ruOay59YtMnxm_QC_RG9af0k/view?usp=drive_link
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]
 
   # cutouts bundle of the cutouts folder for North Eurasia
-  # Size about 19.6 GB (zipped)
+  # Size about 21 GB (zipped)
   bundle_cutouts_northeurasia:
     countries: ["LT", "LV", "EE", "BY", "RU", "KZ", "MN", "GE"]
     category: cutouts
     destination: "cutouts"
     urls:
-      gdrive: https://drive.google.com/file/d/11EzaAaP4eOPzhfKCkm0zZ6HOv-JpgZFd/view?usp=sharing
+      zenodo: https://zenodo.org/records/18920577/files/bundle_cutouts_northeurasia.zip?download=1
+      gdrive: https://drive.google.com/file/d/1yCPS_DVFHfOU2MzPSqTBuVInrZ3cSlRu/view?usp=drive_link
     output: [cutouts/cutout-2013-era5.nc]
     disable_by_opt:
       build_cutout: [all]

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -12,6 +12,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **New Features and Major Changes**
 
+* Update databundle links to zenodo release [PR #1984](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1984)
+
 * Include new storage technologies such as li-ion, vanadium, lfp, lair, pair and iron-air. These technologies can now be configured as either store-link combinations or standalone storage units. Implemented in both ``add_electricity.py`` and ``prepare_sector_network.py`` [PR #1731](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1731)
 
 * Remove `demand` and `h2export` wildcards from sector model [PR #1962](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1962)

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -12,7 +12,7 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **New Features and Major Changes**
 
-* Update databundle links to zenodo release [PR #1984](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1984)
+* Update databundle links to point to the new zenodo release [PR #1984](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1984)
 
 * Include new storage technologies such as li-ion, vanadium, lfp, lair, pair and iron-air. These technologies can now be configured as either store-link combinations or standalone storage units. Implemented in both ``add_electricity.py`` and ``prepare_sector_network.py`` [PR #1731](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1731)
 


### PR DESCRIPTION
# Closes # (if applicable)

## Changes proposed in this Pull Request

This PR updates all databundles to list updated zenodo release of all cutouts and databundles for default and tutorial cases, including gdrive backup.
The databundles are created using the data and code shared in https://drive.google.com/drive/u/2/folders/1l6FfWdU6WEHxWQi0lB0bPvtW5nY54Ir6 for reproducibility.
This means that for future releases, we can first update the data in the folder "data" in the shared drive above and then using the notebook "zip_folders" to re-create the whole bundles.
This reduces significantly the burden to create or edit bundles

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
