### PR TITLE
Option to fill missing hydro technologies

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -639,6 +639,7 @@ rule build_powerplants:
         alternative_clustering=config["clustering"]["alternative_clustering"],
         powerplants_filter=config["electricity"]["powerplants_filter"],
         custom_powerplants=config["electricity"]["custom_powerplants"],
+        fill_missing_hydro_tech=config["electricity"]["fill_missing_hydro_tech"],
     input:
         base_network="networks/" + RDIR + "base.nc",
         pm_config="configs/powerplantmatching_config.yaml",

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -218,6 +218,7 @@ electricity:
 
   # ----------------- Existing powerplants -------------------
   powerplants_filter: (DateOut >= 2022 or DateOut != DateOut) and (DateIn <= 2023 or DateIn != DateIn)
+  fill_missing_hydro_tech: false # Methodology to fill missing technology for hydro powerplants. Accepted values: "ror" (run-of-river) to assume run-of-river technology, "reservoir" for hydro reservoirs, "reservoir-X" for reservoirs with at least X MW capacity and ror for the others, and false for a heuristic based on the hydro inflows.
   custom_powerplants:
     filepaths:  # list of custom powerplant files used in "merge" and "replace" options
     - data/custom_powerplants.csv

--- a/doc/configtables/snippets/electricity.yaml
+++ b/doc/configtables/snippets/electricity.yaml
@@ -22,6 +22,7 @@ electricity:
 
   # ----------------- Existing powerplants -------------------
   powerplants_filter: (DateOut >= 2022 or DateOut != DateOut) and (DateIn <= 2023 or DateIn != DateIn)
+  fill_missing_hydro_tech: false # Methodology to fill missing technology for hydro powerplants. Accepted values: "ror" (run-of-river) to assume run-of-river technology, "reservoir" for hydro reservoirs, "reservoir-X" for reservoirs with at least X MW capacity and ror for the others, and false for a heuristic based on the hydro inflows.
   custom_powerplants:
     filepaths:  # list of custom powerplant files used in "merge" and "replace" options
     - data/custom_powerplants.csv

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -13,6 +13,7 @@ Relevant Settings
 
     electricity:
       powerplants_filter:
+      fill_missing_hydro_tech:
       custom_powerplants:
         filepaths:
         method:
@@ -398,6 +399,56 @@ def replace_natural_gas_technology(df: pd.DataFrame):
     return df
 
 
+def fill_missing_hydro_tech(ppl: pd.DataFrame, fill_missing_hydro_tech: str):
+    """
+    Fill missing hydro technologies in the powerplants.csv based on the specified methodology:
+    - ``ror``: Assign "Run-Of-River" to all hydro powerplants with missing technology.
+    - ``reservoir``: Assign "Reservoir" to all hydro powerplants with missing technology.
+    - ``reservoir-X``: Assign "Reservoir" to hydro powerplants with capacity greater than or equal to X MW, and "Run-Of-River" to those with capacity less than X MW.
+    - ``false``: Do not fill missing hydro technologies.
+
+    Parameters
+    ----------
+    ppl : pd.DataFrame
+        Powerplantmatching dataframe.
+    fill_missing_hydro_tech : str
+        Methodology to fill missing hydro technologies. Accepted values are "ror", "reservoir", "reservoir-X", or false.
+
+    Returns
+    -------
+    pd.DataFrame
+        Powerplant dataframe with filled hydro technologies.
+    """
+    if not fill_missing_hydro_tech:
+        return ppl
+    configmap = {
+        "ror": "Run-Of-River",
+        "reservoir": "Reservoir",
+    }
+    codes = fill_missing_hydro_tech.split("-")
+    method = codes[0]
+    min_capacity = float(codes[1]) if len(codes) > 1 else -np.inf
+    if fill_missing_hydro_tech not in configmap:
+        raise ValueError(
+            f"Unknown fill_missing_hydro_tech value: {fill_missing_hydro_tech}. "
+            "Accepted values are 'ror', 'reservoir', 'reservoir-X', or false."
+        )
+    hydro_b = ppl["Fueltype"] == "Hydro"
+    hydro_missing_tech_b = hydro_b & ppl["Technology"].isnull()
+    if hydro_missing_tech_b.any():
+        n_missing_hydro = hydro_missing_tech_b.sum()
+        n_total_hydro = hydro_b.sum()
+        logger.info(
+            f"Filling missing hydro technology for {n_missing_hydro} "
+            f"out of {n_total_hydro} hydro powerplants."
+        )
+        ror_idx = hydro_b & (ppl["Capacity"] < min_capacity)
+        reservoir_idx = hydro_b & (ppl["Capacity"] >= min_capacity)
+        ppl.loc[ror_idx, "Technology"] = configmap["ror"]
+        ppl.loc[reservoir_idx, "Technology"] = configmap["reservoir"]
+    return ppl
+
+
 if __name__ == "__main__":
     if "snakemake" not in globals():
         from _helpers import mock_snakemake
@@ -502,5 +553,8 @@ if __name__ == "__main__":
             snakemake.params.alternative_clustering,
             col_out="region_id",
         ).rename(columns={"x": "lon", "y": "lat", "country": "Country"})
+
+    # Fill missing hydro technologies
+    ppl = fill_missing_hydro_tech(ppl, snakemake.params.fill_missing_hydro_tech)
 
     ppl.to_csv(snakemake.output.powerplants)

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -416,9 +416,31 @@ def rescale_hydro(plants, runoff, normalize_using_yearly, normalization_year):
             f"Missing hydro statistics for year {normalization_year}; no normalization performed."
         )
     else:
-        # get buses that have installed hydro capacity to be used to compute
-        # the normalization
-        normalization_buses = plants[plants.installed_hydro == True].index
+        p_nom = xr.DataArray(
+            plants["p_nom"],
+            dims=("plant",),
+            coords={"plant": plants.index},
+        )
+        country_of_plant = xr.DataArray(
+            plants["countries"],
+            dims=("plant",),
+            coords={"plant": plants.index},
+        )
+
+        reservoir_buses = plants.query(
+            "technology not in ['Run-of-River', 'Pumped Storage']"
+        ).index  # Note: this implicitly induce the unknown hydro technologies to be treated as reservoirs
+
+        mask_reservoirs = runoff["plant"].isin(reservoir_buses)
+
+        # expected energy
+        common_countries = normalize_using_yearly.columns.intersection(country_of_plant)
+
+        exp_en_by_cnt = xr.DataArray(
+            normalize_using_yearly.loc[ref_year, common_countries].values,
+            dims=("country",),
+            coords={"country": common_countries.values},
+        )
 
         # check nans
         share_nans = float(runoff.isnull().sum() / runoff.shape[0] / runoff.shape[1])

--- a/scripts/build_renewable_profiles.py
+++ b/scripts/build_renewable_profiles.py
@@ -416,31 +416,9 @@ def rescale_hydro(plants, runoff, normalize_using_yearly, normalization_year):
             f"Missing hydro statistics for year {normalization_year}; no normalization performed."
         )
     else:
-        p_nom = xr.DataArray(
-            plants["p_nom"],
-            dims=("plant",),
-            coords={"plant": plants.index},
-        )
-        country_of_plant = xr.DataArray(
-            plants["countries"],
-            dims=("plant",),
-            coords={"plant": plants.index},
-        )
-
-        reservoir_buses = plants.query(
-            "technology not in ['Run-of-River', 'Pumped Storage']"
-        ).index  # Note: this implicitly induce the unknown hydro technologies to be treated as reservoirs
-
-        mask_reservoirs = runoff["plant"].isin(reservoir_buses)
-
-        # expected energy
-        common_countries = normalize_using_yearly.columns.intersection(country_of_plant)
-
-        exp_en_by_cnt = xr.DataArray(
-            normalize_using_yearly.loc[ref_year, common_countries].values,
-            dims=("country",),
-            coords={"country": common_countries.values},
-        )
+        # get buses that have installed hydro capacity to be used to compute
+        # the normalization
+        normalization_buses = plants[plants.installed_hydro == True].index
 
         # check nans
         share_nans = float(runoff.isnull().sum() / runoff.shape[0] / runoff.shape[1])

--- a/test/config.landlock.yaml
+++ b/test/config.landlock.yaml
@@ -21,6 +21,7 @@ electricity:
   extendable_carriers:
     Generator: [solar, onwind, OCGT]
   renewable_carriers: [solar, csp, onwind, hydro]
+  fill_missing_hydro_tech: "reservoir"
 
 osm:
   build_osm_network:


### PR DESCRIPTION
# Closes # (if applicable)

## Changes proposed in this Pull Request

This PR proposes an option derived from #1707 on an option to fill the technology column of hydro powerplants.
I share this to separate its discussion from #1707 

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [ ] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
