### PR TITLE
Apply powerplant filter to custom datasets

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -62,6 +62,8 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
+* Apply powerplant filter to custom datasets [PR #1995](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1995)
+
 * Fix broken EDGAR v6.0 download URL and externalize CO2 emission data retrieval into dedicated `retrieve_emissions` and `build_co2_emissions` Snakemake rules; update `emission_extractor` in `prepare_network.py` to read the pre-built CSV [PR #1877](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1877)
 
 * Add docstrings to build_natura_raster script [PR ##1844](https://github.com/

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -463,10 +463,7 @@ if __name__ == "__main__":
         ppl=ppl,
         custom_powerplants_files=list(snakemake.input.custom_powerplants),
         method=custom_method,
-    )
-
-    if isinstance(ppl_query, str) and ppl_query.strip():
-        ppl = ppl.query(ppl_query)
+    ).query(ppl_query)
 
     ppl = ppl.powerplant.convert_country_to_alpha2().pipe(
         replace_natural_gas_technology

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -40,7 +40,7 @@ Outputs
 Description
 -----------
 
-The configuration option ``electricity: powerplants_filter`` specifies a `pandas.query <https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.query.html>`_ command applied to the original powerplantmatching database. Country conditions must therefore use the full country names found in the original database, such as ``United States``. Country values are converted to ISO alpha-2 codes after the custom powerplant files have been applied.
+The configuration option ``electricity: powerplants_filter`` specifies a `pandas.query` command applied to the complete powerplant dataset, including both powerplantmatching and custom powerplants.
 
 The ``electricity: custom_powerplants`` section specifies the custom files and how they are applied. ``method`` accepts ``false``, ``merge``, or ``replace`` and is applied once to the complete set of configured files. ``merge`` appends all configured custom powerplants to the filtered powerplantmatching dataset, while ``replace`` discards the complete powerplantmatching dataset and uses all configured custom files instead.
 
@@ -463,6 +463,13 @@ if __name__ == "__main__":
         ppl=ppl,
         custom_powerplants_files=list(snakemake.input.custom_powerplants),
         method=custom_method,
+    )
+
+    if isinstance(ppl_query, str) and ppl_query.strip():
+        ppl = ppl.query(ppl_query)
+
+    ppl = ppl.powerplant.convert_country_to_alpha2().pipe(
+        replace_natural_gas_technology
     )
 
     ppl = ppl.powerplant.convert_country_to_alpha2().pipe(

--- a/scripts/build_powerplants.py
+++ b/scripts/build_powerplants.py
@@ -472,10 +472,6 @@ if __name__ == "__main__":
         replace_natural_gas_technology
     )
 
-    ppl = ppl.powerplant.convert_country_to_alpha2().pipe(
-        replace_natural_gas_technology
-    )
-
     # define unique index
     ppl = ppl.reset_index(drop=True)
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

Apply electricity.powerplants_filter to the complete powerplant dataset, including custom powerplants loaded with merge or replace as it wasn't happening in the current implementation (#1945). 
The filter is now applied after custom powerplants are merged or used as a replacement, and no configuration changes are required.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
