### PR TITLE
Fix: missing gadm regions by adding synthetic buses for gadm regions without existing (base) grid

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -335,6 +335,8 @@ rule base_network:
         hvdc_as_lines=config["electricity"]["hvdc_as_lines"],
         countries=config["countries"],
         base_network=config["base_network"],
+        alternative_clustering=config["clustering"]["alternative_clustering"],
+        crs=config["crs"],
     input:
         osm_buses="resources/" + RDIR + "base_network/all_buses_build_network.csv",
         osm_lines="resources/" + RDIR + "base_network/all_lines_build_network.csv",
@@ -346,6 +348,7 @@ rule base_network:
         + "base_network/all_transformers_build_network.csv",
         country_shapes="resources/" + RDIR + "shapes/country_shapes.geojson",
         offshore_shapes="resources/" + RDIR + "shapes/offshore_shapes.geojson",
+        gadm_shapes="resources/" + RDIR + "shapes/gadm_shapes.geojson",
     output:
         "networks/" + RDIR + "base.nc",
     log:

--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -61,6 +61,8 @@ This part of documentation collects descriptive release notes to capture the mai
 * Reorganize config for ``co2``, ``solar_thermal``, and line length settings. Old config keys will be depreciated in future releases [PR #1863](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1863)
 
 **Minor Changes and bug-fixing**
+* Fix missing GADM regions in alternative clustering by adding synthetic AC buses and expandable connecting lines for regions without existing base-grid coverage [PR #1998](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1998)
+
 * Fix invalid biomass transport and CO2 pipeline connections [PR #1987](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1987)
 
 * Attach existing batteries as ``StorageUnit`` rather than Store+Link, so extra battery buses do not inflate the minimum cluster count during simplify/cluster [PR #1990](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1990)

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -311,7 +311,45 @@ def ensure_gadm_bus_coverage(
     geo_crs: str = "EPSG:4326",
     distance_crs: str = "EPSG:3857",
 ) -> tuple[pd.DataFrame, pd.DataFrame, list[str]]:
-    """Add connected AC buses for GADM regions without an LV bus."""
+    """Ensure that each selected GADM region has a connected AC/LV bus.
+
+    Regions are considered covered when an existing AC bus marked as an LV
+    substation is nearest to the region in the projected coordinate system.
+    For every missing region, the function places a new bus at the geometry's
+    representative point, copies the remaining bus attributes from the
+    nearest existing AC bus in the same country, and connects the new bus to
+    that anchor with an AC line.  GADM geometries are first normalised to
+    ``geo_crs`` and then transformed to ``distance_crs`` for nearest-neighbour
+    calculations. 
+
+    Parameters
+    ----------
+    buses : pd.DataFrame
+        Bus table indexed by bus ID.  It must contain ``x``, ``y``,
+        ``country``, ``carrier``, and ``substation_lv`` columns so that
+        existing LV buses and same-country AC anchor buses can be identified.
+    lines : pd.DataFrame
+        Line table containing ``bus0`` and ``bus1`` columns. 
+    gadm_shapes_path : str | None
+        Path to a GADM vector file containing a ``GADM_ID`` column, a
+        ``country`` column, and polygon geometries.
+    countries : list[str]
+        ISO 3166-1 alpha-2 country codes whose GADM regions should be checked
+        and, when necessary, supplemented with new buses.
+    geo_crs : str, optional
+        CRS used for bus and GADM geographic coordinates. GADM files without
+        a CRS are assigned this CRS; files with a CRS are reprojected to it.
+    distance_crs : str, optional
+        Projected CRS used for nearest-neighbour and anchor-distance
+        calculations.
+
+    Returns
+    -------
+    tuple[pd.DataFrame, pd.DataFrame, list[str]]
+        The updated bus table, the updated line table, and the IDs of the
+        generated GADM connection lines. Empty input coverage or no missing
+        regions returns the copied input tables and an empty list.
+    """
     if not gadm_shapes_path:
         raise ValueError("A GADM shapes path is required for GADM bus coverage.")
 
@@ -960,10 +998,10 @@ def base_network(
     snapshots_config: dict,
     transformers_config: dict,
     voltages_config: list,
-    gadm_shapes=None,
-    alternative_clustering=False,
-    geo_crs="EPSG:4326",
-    distance_crs="EPSG:3857",
+    gadm_shapes: str | None = None,
+    alternative_clustering: bool = False,
+    geo_crs: str = "EPSG:4326",
+    distance_crs: str = "EPSG:3857",
 ) -> "pypsa.Network":
     """Build the base PyPSA network from OSM-derived component tables.
 
@@ -1070,9 +1108,9 @@ def base_network(
 
     _set_lines_s_nom_from_linetypes(n)
     if gadm_connection_lines:
-        n.lines.loc[gadm_connection_lines, "s_nom"] = 1.0
+        n.lines.loc[gadm_connection_lines, "s_nom"] = 0.0
         n.lines.loc[gadm_connection_lines, "s_nom_extendable"] = True
-        n.lines.loc[gadm_connection_lines, "s_nom_min"] = 1.0
+        n.lines.loc[gadm_connection_lines, "s_nom_min"] = 0.0
         n.lines.loc[gadm_connection_lines, "s_nom_max"] = lines_config.get(
             "s_nom_max", np.inf
         )

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -329,9 +329,9 @@ def ensure_gadm_bus_coverage(
         )
     gadm_shapes = gadm_shapes.set_index("GADM_ID")
     gadm_shapes.index = gadm_shapes.index.astype(str)
-    gadm_shapes = gadm_shapes.loc[
-        gadm_shapes.country.isin(countries)
-    ].loc[lambda frame: ~frame.index.duplicated(keep="first")]
+    gadm_shapes = gadm_shapes.loc[gadm_shapes.country.isin(countries)].loc[
+        lambda frame: ~frame.index.duplicated(keep="first")
+    ]
     if gadm_shapes.empty:
         return buses, lines, []
 
@@ -348,12 +348,8 @@ def ensure_gadm_bus_coverage(
     ]
     existing_regions = []
     for country in countries:
-        country_buses = existing_lv_buses.loc[
-            existing_lv_buses.country.eq(country)
-        ]
-        country_shapes = gadm_shapes_metric.loc[
-            gadm_shapes_metric.country.eq(country)
-        ]
+        country_buses = existing_lv_buses.loc[existing_lv_buses.country.eq(country)]
+        country_shapes = gadm_shapes_metric.loc[gadm_shapes_metric.country.eq(country)]
         if country_buses.empty or country_shapes.empty:
             continue
         bus_points = gpd.GeoDataFrame(
@@ -361,9 +357,7 @@ def ensure_gadm_bus_coverage(
             geometry=gpd.points_from_xy(country_buses.x, country_buses.y),
             crs=geo_crs,
         ).to_crs(distance_crs)
-        joined = gpd.sjoin_nearest(
-            bus_points, country_shapes, how="left"
-        )
+        joined = gpd.sjoin_nearest(bus_points, country_shapes, how="left")
         joined = joined[~joined.index.duplicated(keep="first")]
         existing_regions.extend(joined["GADM_ID"].dropna().astype(str))
     existing_regions = pd.Index(existing_regions, dtype=str).unique()
@@ -391,21 +385,21 @@ def ensure_gadm_bus_coverage(
     new_lines = {}
     for gadm_id in missing_regions:
         country = gadm_shapes.at[gadm_id, "country"]
-        country_ac_buses = existing_ac_buses.loc[
-            existing_ac_buses.country.eq(country)
-        ]
+        country_ac_buses = existing_ac_buses.loc[existing_ac_buses.country.eq(country)]
         if country_ac_buses.empty:
             raise ValueError(
                 f"Cannot add GADM region {gadm_id}: no existing AC bus in country {country}."
             )
 
         region_point = gadm_shapes.at[gadm_id, "geometry"].representative_point()
-        region_point_metric = gpd.GeoSeries(
-            [region_point], crs=geo_crs
-        ).to_crs(distance_crs).iloc[0]
-        anchor_bus = existing_ac_points.loc[country_ac_buses.index].distance(
-            region_point_metric
-        ).idxmin()
+        region_point_metric = (
+            gpd.GeoSeries([region_point], crs=geo_crs).to_crs(distance_crs).iloc[0]
+        )
+        anchor_bus = (
+            existing_ac_points.loc[country_ac_buses.index]
+            .distance(region_point_metric)
+            .idxmin()
+        )
         bus_name = f"{gadm_id}_AC"
         if bus_name in buses.index or bus_name in new_buses:
             raise ValueError(f"Bus name {bus_name} already exists.")

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -320,7 +320,7 @@ def ensure_gadm_bus_coverage(
     nearest existing AC bus in the same country, and connects the new bus to
     that anchor with an AC line.  GADM geometries are first normalised to
     ``geo_crs`` and then transformed to ``distance_crs`` for nearest-neighbour
-    calculations. 
+    calculations.
 
     Parameters
     ----------
@@ -329,7 +329,7 @@ def ensure_gadm_bus_coverage(
         ``country``, ``carrier``, and ``substation_lv`` columns so that
         existing LV buses and same-country AC anchor buses can be identified.
     lines : pd.DataFrame
-        Line table containing ``bus0`` and ``bus1`` columns. 
+        Line table containing ``bus0`` and ``bus1`` columns.
     gadm_shapes_path : str | None
         Path to a GADM vector file containing a ``GADM_ID`` column, a
         ``country`` column, and polygon geometries.

--- a/scripts/base_network.py
+++ b/scripts/base_network.py
@@ -66,6 +66,8 @@ import scipy as sp
 import shapely.prepared
 import shapely.wkt
 from _helpers import configure_logging, create_logger, read_csv_nafix
+from pypsa.geo import haversine_pts
+from shapely.geometry import LineString, MultiPoint, Point
 from shapely.ops import unary_union
 
 logger = create_logger(__name__)
@@ -299,6 +301,172 @@ def _load_lines_from_osm(fp_osm_lines: str) -> pd.DataFrame:
     # lines = _remove_dangling_branches(lines, buses)  # TODO: add dangling branch removal?
 
     return lines
+
+
+def ensure_gadm_bus_coverage(
+    buses: pd.DataFrame,
+    lines: pd.DataFrame,
+    gadm_shapes_path: str | None,
+    countries: list[str],
+    geo_crs: str = "EPSG:4326",
+    distance_crs: str = "EPSG:3857",
+) -> tuple[pd.DataFrame, pd.DataFrame, list[str]]:
+    """Add connected AC buses for GADM regions without an LV bus."""
+    if not gadm_shapes_path:
+        raise ValueError("A GADM shapes path is required for GADM bus coverage.")
+
+    buses = buses.copy()
+    lines = lines.copy()
+    buses.index = buses.index.astype(str)
+    for column in ("bus0", "bus1"):
+        if column in lines:
+            lines[column] = lines[column].astype(str)
+
+    gadm_shapes = gpd.read_file(gadm_shapes_path)
+    if "GADM_ID" not in gadm_shapes.columns:
+        raise ValueError(
+            f"GADM input {gadm_shapes_path} must contain a `GADM_ID` column."
+        )
+    gadm_shapes = gadm_shapes.set_index("GADM_ID")
+    gadm_shapes.index = gadm_shapes.index.astype(str)
+    gadm_shapes = gadm_shapes.loc[
+        gadm_shapes.country.isin(countries)
+    ].loc[lambda frame: ~frame.index.duplicated(keep="first")]
+    if gadm_shapes.empty:
+        return buses, lines, []
+
+    if gadm_shapes.crs is None:
+        gadm_shapes = gadm_shapes.set_crs(geo_crs)
+    else:
+        gadm_shapes = gadm_shapes.to_crs(geo_crs)
+    gadm_shapes_metric = gadm_shapes.to_crs(distance_crs)
+
+    existing_lv_buses = buses.loc[
+        buses.country.isin(countries)
+        & buses.carrier.eq("AC")
+        & buses.substation_lv.fillna(False).astype(bool)
+    ]
+    existing_regions = []
+    for country in countries:
+        country_buses = existing_lv_buses.loc[
+            existing_lv_buses.country.eq(country)
+        ]
+        country_shapes = gadm_shapes_metric.loc[
+            gadm_shapes_metric.country.eq(country)
+        ]
+        if country_buses.empty or country_shapes.empty:
+            continue
+        bus_points = gpd.GeoDataFrame(
+            country_buses[["x", "y", "country"]],
+            geometry=gpd.points_from_xy(country_buses.x, country_buses.y),
+            crs=geo_crs,
+        ).to_crs(distance_crs)
+        joined = gpd.sjoin_nearest(
+            bus_points, country_shapes, how="left"
+        )
+        joined = joined[~joined.index.duplicated(keep="first")]
+        existing_regions.extend(joined["GADM_ID"].dropna().astype(str))
+    existing_regions = pd.Index(existing_regions, dtype=str).unique()
+
+    missing_regions = gadm_shapes.index.difference(existing_regions).sort_values()
+    if missing_regions.empty:
+        return buses, lines, []
+
+    existing_ac_buses = buses.loc[
+        buses.country.isin(countries) & buses.carrier.eq("AC")
+    ]
+    if existing_ac_buses.empty:
+        raise ValueError(
+            "Cannot add GADM buses because no existing AC bus is available "
+            "as a connection point."
+        )
+
+    existing_ac_points = gpd.GeoDataFrame(
+        existing_ac_buses[["x", "y", "country"]],
+        geometry=gpd.points_from_xy(existing_ac_buses.x, existing_ac_buses.y),
+        crs=geo_crs,
+    ).to_crs(distance_crs)
+
+    new_buses = {}
+    new_lines = {}
+    for gadm_id in missing_regions:
+        country = gadm_shapes.at[gadm_id, "country"]
+        country_ac_buses = existing_ac_buses.loc[
+            existing_ac_buses.country.eq(country)
+        ]
+        if country_ac_buses.empty:
+            raise ValueError(
+                f"Cannot add GADM region {gadm_id}: no existing AC bus in country {country}."
+            )
+
+        region_point = gadm_shapes.at[gadm_id, "geometry"].representative_point()
+        region_point_metric = gpd.GeoSeries(
+            [region_point], crs=geo_crs
+        ).to_crs(distance_crs).iloc[0]
+        anchor_bus = existing_ac_points.loc[country_ac_buses.index].distance(
+            region_point_metric
+        ).idxmin()
+        bus_name = f"{gadm_id}_AC"
+        if bus_name in buses.index or bus_name in new_buses:
+            raise ValueError(f"Bus name {bus_name} already exists.")
+
+        bus = buses.loc[anchor_bus].copy()
+        bus_values = {
+            "x": region_point.x,
+            "y": region_point.y,
+            "lon": region_point.x,
+            "lat": region_point.y,
+            "country": country,
+            "carrier": "AC",
+            "substation_lv": True,
+            "substation_off": False,
+            "geometry": Point(region_point.x, region_point.y).wkt,
+        }
+        for column, value in bus_values.items():
+            if column in bus.index:
+                bus[column] = value
+        new_buses[bus_name] = bus
+
+        line_name = f"gadm_{gadm_id}_connection"
+        while line_name in lines.index or line_name in new_lines:
+            line_name += "_"
+        anchor = buses.loc[anchor_bus]
+        line = lines.iloc[0].copy() if not lines.empty else pd.Series(dtype=object)
+        line_values = {
+            "bus0": bus_name,
+            "bus1": anchor_bus,
+            "length": float(
+                haversine_pts(
+                    [region_point.x, region_point.y],
+                    [anchor.x, anchor.y],
+                )
+            ),
+            "v_nom": anchor.v_nom,
+            "num_parallel": 1.0,
+            "dc": False,
+            "geometry": LineString(
+                [(region_point.x, region_point.y), (anchor.x, anchor.y)]
+            ).wkt,
+            "bounds": MultiPoint(
+                [(region_point.x, region_point.y), (anchor.x, anchor.y)]
+            ).wkt,
+        }
+        for column, value in line_values.items():
+            line[column] = value
+        new_lines[line_name] = line
+
+    buses = pd.concat(
+        [buses, pd.DataFrame.from_dict(new_buses, orient="index")], axis=0
+    )
+    lines = pd.concat(
+        [lines, pd.DataFrame.from_dict(new_lines, orient="index")], axis=0
+    )
+    logger.info(
+        "Added %d AC buses to cover missing GADM regions: %s",
+        len(new_buses),
+        ", ".join(sorted(new_buses)),
+    )
+    return buses, lines, list(new_lines)
 
 
 # TODO Seems to be not needed anymore
@@ -798,6 +966,10 @@ def base_network(
     snapshots_config: dict,
     transformers_config: dict,
     voltages_config: list,
+    gadm_shapes=None,
+    alternative_clustering=False,
+    geo_crs="EPSG:4326",
+    distance_crs="EPSG:3857",
 ) -> "pypsa.Network":
     """Build the base PyPSA network from OSM-derived component tables.
 
@@ -810,10 +982,8 @@ def base_network(
 
     Parameters
     ----------
-    inputs : snakemake.io.Namedlist
-        Snakemake input paths: ``osm_buses``, ``osm_lines``,
-        ``osm_transformers``, ``osm_converters``, ``country_shapes``,
-        ``offshore_shapes``.
+    inputs : object
+        Snakemake input paths for OSM network data and geographic shapes.
     base_network_config : dict
         ``base_network`` section of ``config.yaml``.
     countries_config : list
@@ -830,6 +1000,14 @@ def base_network(
         ``transformers`` section of ``config.yaml``.
     voltages_config : list
         Nominal voltages (kV) to retain.
+    gadm_shapes : str | None, optional
+        Path to the GADM shapes file used for alternative clustering.
+    alternative_clustering : bool, optional
+        Whether to add buses for GADM regions without an existing LV bus.
+    geo_crs : str, optional
+        Coordinate reference system used for geographic coordinates.
+    distance_crs : str, optional
+        Projected coordinate reference system used for distance calculations.
 
     Returns
     -------
@@ -839,6 +1017,16 @@ def base_network(
     """
     buses = _load_buses_from_osm(inputs.osm_buses).reset_index(drop=True)
     lines = _load_lines_from_osm(inputs.osm_lines).reset_index(drop=True)
+    gadm_connection_lines = []
+    if alternative_clustering:
+        buses, lines, gadm_connection_lines = ensure_gadm_bus_coverage(
+            buses,
+            lines,
+            gadm_shapes,
+            countries_config,
+            geo_crs=geo_crs,
+            distance_crs=distance_crs,
+        )
     transformers = _load_transformers_from_osm(inputs.osm_transformers, buses)
     converters = _load_converters_from_osm(inputs.osm_converters, buses)
 
@@ -887,6 +1075,13 @@ def base_network(
     n.lines.drop(columns="under_construction", inplace=True, errors="ignore")
 
     _set_lines_s_nom_from_linetypes(n)
+    if gadm_connection_lines:
+        n.lines.loc[gadm_connection_lines, "s_nom"] = 1.0
+        n.lines.loc[gadm_connection_lines, "s_nom_extendable"] = True
+        n.lines.loc[gadm_connection_lines, "s_nom_min"] = 1.0
+        n.lines.loc[gadm_connection_lines, "s_nom_max"] = lines_config.get(
+            "s_nom_max", np.inf
+        )
 
     _set_countries_and_substations(inputs, base_network_config, countries_config, n)
 
@@ -915,6 +1110,8 @@ if __name__ == "__main__":
     snapshots = snakemake.params.snapshots
     transformers = snakemake.params.transformers
     voltages = snakemake.params.voltages
+    alternative_clustering = snakemake.params.alternative_clustering
+    crs = snakemake.params.crs
 
     n = base_network(
         inputs,
@@ -926,6 +1123,10 @@ if __name__ == "__main__":
         snapshots,
         transformers,
         voltages,
+        gadm_shapes=snakemake.input.gadm_shapes,
+        alternative_clustering=alternative_clustering,
+        geo_crs=crs["geo_crs"],
+        distance_crs=crs["distance_crs"],
     )
 
     n.buses = pd.DataFrame(n.buses.drop(columns="geometry"))

--- a/scripts/cluster_network.py
+++ b/scripts/cluster_network.py
@@ -758,9 +758,11 @@ if __name__ == "__main__":
         busmap = n.buses.index.to_series()
         linemap = n.lines.index.to_series()
         clustering = pypsa.clustering.spatial.Clustering(n, busmap, linemap)
-    elif len(n.buses) < n_clusters:
-        logger.error(
-            f"Desired number of clusters ({n_clusters}) higher than the number of buses ({len(n.buses)})"
+    elif len(n.buses) < n_clusters and not alternative_clustering:
+        raise ValueError(
+            f"Desired number of clusters ({n_clusters}) cannot be higher than "
+            f"the number of buses ({len(n.buses)}). Set `scenario.clusters` "
+            "to a value between 1 and the number of buses."
         )
     else:
         line_length_factor = snakemake.params.length_factor


### PR DESCRIPTION
This pull request introduces support for "alternative clustering" in the base network construction, ensuring that all GADM (administrative) regions are covered by at least one LV (low voltage) AC bus. It adds new parameters and logic to both the Snakemake workflow and the `base_network.py` script to enable this feature. 
This fixes the issue of missing/dropped gadm regions for MR and CD. For these countries GADM regions currently get dropped along base_network and simplify_network:
<img width="751" height="495" alt="image" src="https://github.com/user-attachments/assets/25c77b2b-4d01-4937-9912-5fb64fefea1f" />

With fix: 
<img width="808" height="578" alt="image" src="https://github.com/user-attachments/assets/6e7c95b8-a50a-4883-953e-944c2593adb7" />


Additional fix: The PR also fixes the condition: len(n.buses) < n_clusters by adding "and not alternative_clustering".

@doneachh @AlexanderMeisinger @ekatef @yerbol-akhmetov 

## Changes proposed in this Pull Request
Base Network Script and Rule:

* Added a new function `ensure_gadm_bus_coverage` in `base_network.py` that adds connected AC buses for GADM regions lacking an LV bus, ensuring comprehensive regional coverage.
* Updated the `base_network` function to accept new parameters for GADM shapes, alternative clustering, and coordinate reference systems, and to call `ensure_gadm_bus_coverage` when alternative clustering is enabled. 
* When new GADM connection lines are added, set their electrical parameters (`s_nom`, `s_nom_extendable`, `s_nom_min`, `s_nom_max`) appropriately in the network.
* Modified the `Snakefile` to pass new parameters (`alternative_clustering`, `crs`) and the GADM shapes file to the base network rule, enabling the new logic via configuration.


## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
