### PR TITLE
Fix `shared_cutouts` logic

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -61,6 +61,9 @@ This part of documentation collects descriptive release notes to capture the mai
 * Reorganize config for ``co2``, ``solar_thermal``, and line length settings. Old config keys will be depreciated in future releases [PR #1863](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1863)
 
 **Minor Changes and bug-fixing**
+
+* Fix `shared_cutouts` logic [PR #2003](https://github.com/pypsa-meets-earth/pypsa-earth/pull/2003)
+
 * Fix invalid biomass transport and CO2 pipeline connections [PR #1987](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1987)
 
 * Attach existing batteries as ``StorageUnit`` rather than Store+Link, so extra battery buses do not inflate the minimum cluster count during simplify/cluster [PR #1990](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1990)

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -158,11 +158,7 @@ def download_and_unzip_zenodo(
     """
     resource = config["category"]
     file_path = os.path.join(rootpath, "tempfile.zip")
-    destination = (
-        os.path.dirname(snakemake.output[0])
-        if resource == "cutouts"
-        else os.path.join(BASE_DIR, config["destination"])
-    )
+    destination = os.path.join(BASE_DIR, config["destination"])
     url = config["urls"]["zenodo"]
 
     if hot_run:
@@ -209,11 +205,7 @@ def download_and_unzip_gdrive(
     """
     resource = config["category"]
     file_path = os.path.join(rootpath, "tempfile.zip")
-    destination = (
-        os.path.dirname(snakemake.output[0])
-        if resource == "cutouts"
-        else os.path.join(BASE_DIR, config["destination"])
-    )
+    destination = os.path.join(BASE_DIR, config["destination"])
     url = config["urls"]["gdrive"]
 
     # retrieve file_id from path
@@ -957,6 +949,7 @@ def retrieve_databundle(
     hydrobasins_level: int,
     rootpath: str = ".",
     disable_progress: bool = False,
+    output_path: str | None = None,
 ) -> None:
     """
     Retrieve the specified databundles and unzip them.
@@ -974,6 +967,9 @@ def retrieve_databundle(
         The root path for the downloaded files.
     disable_progress : bool
         Whether to disable the progress bar.
+    output_path : str, optional
+        Snakemake rule output path. When set, cutout bundles unpack to its
+        parent directory (supports ``shared_cutouts: false``).
 
     Returns
     -------
@@ -990,6 +986,11 @@ def retrieve_databundle(
     )
 
     logger.info("Bundles to be downloaded:\n\t" + "\n\t".join(bundles_to_download))
+
+    if output_path:
+        for b_name in bundles_to_download:
+            if config_bundles[b_name]["category"] == "cutouts":
+                config_bundles[b_name]["destination"] = os.path.dirname(output_path)
 
     hydrobasin_bundles = [
         b_name for b_name in bundles_to_download if "hydrobasins" in b_name
@@ -1140,6 +1141,7 @@ if __name__ == "__main__":
         hydrobasins_level,
         rootpath=rootpath,
         disable_progress=disable_progress,
+        output_path=snakemake.output[0],
     )
 
     if snakemake.input:

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -158,7 +158,11 @@ def download_and_unzip_zenodo(
     """
     resource = config["category"]
     file_path = os.path.join(rootpath, "tempfile.zip")
-    destination = os.path.join(BASE_DIR, config["destination"])
+    destination = (
+        os.path.dirname(snakemake.output[0])
+        if resource == "cutouts"
+        else os.path.join(BASE_DIR, config["destination"])
+    )
     url = config["urls"]["zenodo"]
 
     if hot_run:
@@ -205,7 +209,11 @@ def download_and_unzip_gdrive(
     """
     resource = config["category"]
     file_path = os.path.join(rootpath, "tempfile.zip")
-    destination = os.path.join(BASE_DIR, config["destination"])
+    destination = (
+        os.path.dirname(snakemake.output[0])
+        if resource == "cutouts"
+        else os.path.join(BASE_DIR, config["destination"])
+    )
     url = config["urls"]["gdrive"]
 
     # retrieve file_id from path


### PR DESCRIPTION
# Closes #2000 

## Changes proposed in this Pull Request
Good day. This PR fixes an issue of using `shared_cutouts`. Currently, it does not work properly, because the output of the snakemake rule `retrieve_cutouts` expects cutouts to be in `cutouts/{CDIR}/`. With `shared_cutouts`, `CDIR` becomes name of the run, while cutouts are extracted to `cutouts/` folder based on `bundle_config.yaml` inside `retrieve_databundle_light`. This PR solved the issue,

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [x] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
