### PR TITLE
Retry failed databundle downloads

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -61,6 +61,9 @@ This part of documentation collects descriptive release notes to capture the mai
 * Reorganize config for ``co2``, ``solar_thermal``, and line length settings. Old config keys will be depreciated in future releases [PR #1863](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1863)
 
 **Minor Changes and bug-fixing**
+
+* Retry failed Zenodo databundle downloads to improve retrieval reliability [PR #2013](https://github.com/pypsa-meets-earth/pypsa-earth/pull/2013)
+*
 * Fix invalid biomass transport and CO2 pipeline connections [PR #1987](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1987)
 
 * Attach existing batteries as ``StorageUnit`` rather than Store+Link, so extra battery buses do not inflate the minimum cluster count during simplify/cluster [PR #1990](https://github.com/pypsa-meets-earth/pypsa-earth/pull/1990)

--- a/scripts/retrieve_databundle_light.py
+++ b/scripts/retrieve_databundle_light.py
@@ -132,11 +132,17 @@ def load_databundle_config(config: dict | str) -> dict:
 
 
 def download_and_unzip_zenodo(
-    config: dict, rootpath: str, hot_run: bool = True, disable_progress: bool = False
+    config: dict,
+    rootpath: str,
+    hot_run: bool = True,
+    disable_progress: bool = False,
+    max_retries: int = 3,
 ) -> bool:
     """
-    download_and_unzip_zenodo(config, rootpath, dest_path, hot_run=True,
-    disable_progress=False)
+    download_and_unzip_zenodo(
+        config, rootpath, dest_path, hot_run=True, disable_progress=False,
+        max_retries=3
+    )
 
     Function to download and unzip the data from zenodo
 
@@ -151,6 +157,8 @@ def download_and_unzip_zenodo(
         When false, the workflow is run without downloading and unzipping
     disable_progress : bool (default False)
         When true the progress bar to download data is disabled
+    max_retries : int (default 3)
+        Maximum number of download attempts
 
     Returns
     -------
@@ -162,18 +170,42 @@ def download_and_unzip_zenodo(
     url = config["urls"]["zenodo"]
 
     if hot_run:
-        try:
-            logger.info(f"Downloading resource '{resource}' from cloud '{url}'")
-            progress_retrieve(url, file_path, disable_progress=disable_progress)
-            logger.info(f"Extracting resources")
-            with ZipFile(file_path, "r") as zipObj:
-                # Extract all the contents of zip file in current directory
-                zipObj.extractall(path=destination)
-            os.remove(file_path)
-            logger.info(f"Downloaded resource '{resource}' from cloud '{url}'.")
-        except:
-            logger.warning(f"Failed download resource '{resource}' from cloud '{url}'.")
-            return False
+        for attempt in range(1, max_retries + 1):
+            try:
+                if os.path.exists(file_path):
+                    os.remove(file_path)
+
+                logger.info(
+                    f"Downloading resource '{resource}' from cloud '{url}' "
+                    f"(attempt {attempt}/{max_retries})"
+                )
+                progress_retrieve(
+                    url,
+                    file_path,
+                    disable_progress=disable_progress,
+                )
+                logger.info("Extracting resources")
+                with ZipFile(file_path, "r") as zipObj:
+                    # Extract all the contents of zip file in current directory
+                    zipObj.extractall(path=destination)
+
+                os.remove(file_path)
+                logger.info(f"Downloaded resource '{resource}' from cloud '{url}'.")
+                return True
+
+            except Exception as exc:
+                logger.warning(
+                    f"Failed download resource '{resource}' from cloud '{url}' "
+                    f"on attempt {attempt}/{max_retries}: {exc}"
+                )
+
+                if os.path.exists(file_path):
+                    os.remove(file_path)
+
+                if attempt < max_retries:
+                    time.sleep(10 * attempt)
+
+        return False
 
     return True
 


### PR DESCRIPTION
## Changes proposed in this Pull Request

This PR improves databundle retrieval reliability by retrying failed downloads up to three times before falling back to the next configured host.

The retry logic is handled at the common databundle dispatch level, so it applies consistently to all supported download backends rather than only Zenodo.

Individual download functions remain responsible for a single download attempt and host-specific cleanup.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
