### PR TITLE
Fix CO2 emission year fallback

### DIFF
--- a/doc/release-notes.md
+++ b/doc/release-notes.md
@@ -16,7 +16,7 @@ This part of documentation collects descriptive release notes to capture the mai
 
 **Minor Changes and bug-fixing**
 
-*
+* Fix fallback to closest available CO2 emission year [PR #2018](https://github.com/pypsa-meets-earth/pypsa-earth/pull/2018)
 
 # PyPSA-Earth 0.9.0
 

--- a/scripts/prepare_network.py
+++ b/scripts/prepare_network.py
@@ -89,7 +89,7 @@ def emission_extractor(
         Path to the CSV file produced by build_co2_emissions. The file has
         columns country_code_a3 (three-letter ISO code), country_code_a2
         (two-letter ISO code), country_name (full country name), and year columns
-        named Y_YYYY.
+        named YYYY.
     emission_year : int or str
         Year of CO2 emissions.
     country_names : numpy.ndarray
@@ -119,7 +119,7 @@ def emission_extractor(
 
     country_codes = np.atleast_1d(country_names).tolist()
     available_countries = df.index.intersection(country_codes)
-    emission_by_country = df.loc[available_countries, str(emission_year)]
+    emission_by_country = df.loc[available_countries, str(closest_year)]
     if emission_by_country.index.has_duplicates:
         duplicate_countries = emission_by_country.index[
             emission_by_country.index.duplicated()


### PR DESCRIPTION
## Changes proposed in this Pull Request

Fix `emission_extractor` to actually use the closest available emission year when the configured `co2.automatic_emission.base_year` is not present in the processed EDGAR dataset.

Previously, the function identified and logged the closest available year but still attempted to access the originally requested year, resulting in a KeyError.

The docstring is also corrected to reflect that the processed emission csv contains year columns named `YYYY`, since build_co2_emissions removes the original Y_ prefix before writing the file.

I've tested `emission_extractor` with a requested year not present in the input data and verified that the closest available year is returned.

## Checklist

- [x] I consent to the release of this PR's code under the AGPLv3 license and non-code contributions under CC0-1.0 and CC-BY-4.0.
- [x] I tested my contribution locally and it seems to work fine.
- [ ] Code and workflow changes are sufficiently documented, including updates to docstrings for meaningful functions.
- [ ] Newly introduced dependencies are added to `envs/environment.yaml` and `doc/requirements.txt`.
- [ ] Changes in configuration options are added in all of `config.default.yaml` and `config.tutorial.yaml`.
- [ ] Add a test config or line additions to `test/` (note tests are changing the config.tutorial.yaml)
- [ ] Changes in configuration options are also documented in `doc/configtables/*.csv` and line references are adjusted in `doc/user-guide/configuration.md` and `doc/tutorials/electricity-model.md`.
- [ ] If config sections were added, renamed, or removed, update `doc/assets/scripts/extract_config_snippets.py` accordingly.
- [ ] Archives of the uploaded data do not have an enclosing folder and archive names correspond to the conventions of `configs/bundle_config.yaml`.
- [x] A note for the release notes `doc/release-notes.md` is amended in the format of previous release notes, including reference to the requested PR.
